### PR TITLE
Edit the name of the card type editor's checkmark

### DIFF
--- a/AnkiDroid/src/main/res/menu/card_template_editor.xml
+++ b/AnkiDroid/src/main/res/menu/card_template_editor.xml
@@ -9,7 +9,7 @@
     <item
         android:id="@+id/action_confirm"
         android:icon="@drawable/ic_done_white_24dp"
-        android:title="@string/dialog_ok"
+        android:title="@string/save"
         ankidroid:showAsAction="ifRoom"
         android:visible="true"/>
     <item


### PR DESCRIPTION
Rename the name of the card type editor's checkmark from "OK" to "save"
Fix #4670.