### PR TITLE
Make whiteboard-related items fully grouped

### DIFF
--- a/AnkiDroid/src/androidTest/java/com/ichi2/anki/tests/NotificationChannelTest.kt
+++ b/AnkiDroid/src/androidTest/java/com/ichi2/anki/tests/NotificationChannelTest.kt
@@ -24,7 +24,7 @@ import androidx.test.annotation.UiThreadTest
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.rule.GrantPermissionRule
 import com.ichi2.anki.AnkiDroidApp
-import com.ichi2.anki.NotificationChannels
+import com.ichi2.anki.Channel
 import com.ichi2.compat.CompatHelper.Companion.sdkVersion
 import com.ichi2.utils.KotlinCleanup
 import org.hamcrest.MatcherAssert.assertThat
@@ -72,7 +72,7 @@ class NotificationChannelTest : InstrumentedTest() {
         for (i in channels.indices) {
             Timber.d("Found channel with id %s", channels[i].id)
         }
-        var expectedChannels = NotificationChannels.Channel.values().size
+        var expectedChannels = Channel.values().size
         // If we have channels but have *targeted* pre-26, there is a "miscellaneous" channel auto-defined
         if (mTargetAPI < 26) {
             expectedChannels += 1
@@ -89,7 +89,7 @@ class NotificationChannelTest : InstrumentedTest() {
             expectedChannels,
             greaterThanOrEqualTo(channels.size)
         )
-        for (channel in NotificationChannels.Channel.values()) {
+        for (channel in Channel.values()) {
             assertNotNull(
                 "There should be a reminder channel",
                 mManager!!.getNotificationChannel(channel.id)

--- a/AnkiDroid/src/main/java/com/ichi2/anki/AnkiActivity.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AnkiActivity.kt
@@ -481,12 +481,12 @@ open class AnkiActivity : AppCompatActivity, SimpleMessageDialogListener, Collec
 
     /**
      * Calls [.showAsyncDialogFragment] internally, using the channel
-     * [NotificationChannels.Channel.GENERAL]
+     * [Channel.GENERAL]
      *
      * @param newFragment  the AsyncDialogFragment you want to show
      */
     open fun showAsyncDialogFragment(newFragment: AsyncDialogFragment) {
-        showAsyncDialogFragment(newFragment, NotificationChannels.Channel.GENERAL)
+        showAsyncDialogFragment(newFragment, Channel.GENERAL)
     }
 
     /**
@@ -495,11 +495,11 @@ open class AnkiActivity : AppCompatActivity, SimpleMessageDialogListener, Collec
      * AsyncTask completed
      *
      * @param newFragment  the AsyncDialogFragment you want to show
-     * @param channel the NotificationChannels.Channel to use for the notification
+     * @param channel the Channel to use for the notification
      */
     fun showAsyncDialogFragment(
         newFragment: AsyncDialogFragment,
-        channel: NotificationChannels.Channel
+        channel: Channel
     ) {
         try {
             showDialogFragment(newFragment)
@@ -532,7 +532,7 @@ open class AnkiActivity : AppCompatActivity, SimpleMessageDialogListener, Collec
     fun showSimpleNotification(
         title: String,
         message: String?,
-        channel: NotificationChannels.Channel
+        channel: Channel
     ) {
         val prefs = AnkiDroidApp.getSharedPrefs(this)
         // Show a notification unless all notifications have been totally disabled

--- a/AnkiDroid/src/main/java/com/ichi2/anki/AnkiDroidApp.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AnkiDroidApp.kt
@@ -156,7 +156,7 @@ open class AnkiDroidApp : Application() {
             this,
             preferences.getBoolean(getString(R.string.anki_card_external_context_menu_key), true)
         )
-        NotificationChannels.setup(applicationContext)
+        CompatHelper.compat.setupNotificationChannel(applicationContext)
 
         // Configure WebView to allow file scheme pages to access cookies.
         if (!acceptFileSchemeCookies()) {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/AnkiDroidApp.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AnkiDroidApp.kt
@@ -32,6 +32,7 @@ import android.system.Os
 import android.util.Log
 import android.webkit.CookieManager
 import androidx.annotation.VisibleForTesting
+import androidx.core.content.edit
 import androidx.lifecycle.MutableLiveData
 import com.ichi2.anki.CrashReportService.sendExceptionReport
 import com.ichi2.anki.UIUtils.showThemedToast
@@ -143,7 +144,7 @@ open class AnkiDroidApp : Application() {
 
         // make default HTML / JS debugging true for debug build and disable for unit/android tests
         if (BuildConfig.DEBUG && !AdaptionUtil.isRunningAsUnitTest) {
-            preferences.edit().putBoolean("html_javascript_debugging", true).apply()
+            preferences.edit { putBoolean("html_javascript_debugging", true) }
         }
         CardBrowserContextMenu.ensureConsistentStateWithPreferenceStatus(
             this,

--- a/AnkiDroid/src/main/java/com/ichi2/anki/BackupManager.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/BackupManager.kt
@@ -18,6 +18,7 @@ package com.ichi2.anki
 
 import android.content.SharedPreferences
 import androidx.annotation.VisibleForTesting
+import androidx.core.content.edit
 import com.ichi2.compat.CompatHelper
 import com.ichi2.libanki.Collection
 import com.ichi2.libanki.Utils
@@ -85,7 +86,7 @@ open class BackupManager {
         // Abort backup if not enough free space
         if (!hasFreeDiscSpace(colFile)) {
             Timber.e("performBackup: Not enough space on sd card to backup.")
-            prefs.edit().putBoolean("noSpaceLeft", true).apply()
+            prefs.edit { putBoolean("noSpaceLeft", true) }
             return false
         }
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/BackupManager.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/BackupManager.kt
@@ -61,14 +61,14 @@ open class BackupManager {
             return false
         }
         val colFile = File(colPath)
-        val deckBackups = getBackups(colFile)
-        if (isBackupUnnecessary(colFile, deckBackups)) {
+        val colBackups = getBackups(colFile)
+        if (isBackupUnnecessary(colFile, colBackups)) {
             Timber.d("performBackup: No backup necessary due to no collection changes")
             return false
         }
 
         // Abort backup if one was already made less than [interval] hours ago (default: 5 hours - BACKUP_INTERVAL)
-        val lastBackupDate = getLastBackupDate(deckBackups)
+        val lastBackupDate = getLastBackupDate(colBackups)
         if (lastBackupDate != null && lastBackupDate.time + interval * 3600000L > time.intTimeMS()) {
             Timber.d("performBackup: No backup created. Last backup younger than 5 hours")
             return false
@@ -105,13 +105,13 @@ open class BackupManager {
         return true
     }
 
-    fun isBackupUnnecessary(colFile: File, deckBackups: Array<File>): Boolean {
-        val len = deckBackups.size
+    fun isBackupUnnecessary(colFile: File, colBackups: Array<File>): Boolean {
+        val len = colBackups.size
 
         // If have no backups, then a backup is necessary
         return if (len <= 0) {
             false
-        } else deckBackups[len - 1].lastModified() == colFile.lastModified()
+        } else colBackups[len - 1].lastModified() == colFile.lastModified()
 
         // no collection changes means we don't need a backup
     }
@@ -151,7 +151,7 @@ open class BackupManager {
             zos.close()
             // Delete old backup files if needed
             val prefs = AnkiDroidApp.getSharedPrefs(AnkiDroidApp.instance.baseContext)
-            deleteDeckBackups(colPath, prefs.getInt("backupMax", 8))
+            deleteColBackups(colPath, prefs.getInt("backupMax", 8))
             // set timestamp of file in order to avoid creating a new backup unless its changed
             if (!backupFile.setLastModified(colFile.lastModified())) {
                 Timber.w("performBackupInBackground() setLastModified() failed on file %s", backupFile.name)
@@ -185,7 +185,7 @@ open class BackupManager {
         private const val MIN_FREE_SPACE = 10
         private const val MIN_BACKUP_COL_SIZE = 10000 // threshold in bytes to backup a col file
         private const val BACKUP_SUFFIX = "backup"
-        const val BROKEN_DECKS_SUFFIX = "broken"
+        const val BROKEN_COLLECTIONS_SUFFIX = "broken"
         private val backupNameRegex: Regex by lazy {
             Regex("(?:collection|backup)-((\\d{4})-(\\d{2})-(\\d{2})-(\\d{2})[.-](\\d{2}))(?:\\.\\d{2})?.colpkg")
         }
@@ -210,7 +210,7 @@ open class BackupManager {
         }
 
         private fun getBrokenDirectory(ankidroidDir: File): File {
-            val directory = File(ankidroidDir, BROKEN_DECKS_SUFFIX)
+            val directory = File(ankidroidDir, BROKEN_COLLECTIONS_SUFFIX)
             if (!directory.isDirectory && !directory.mkdirs()) {
                 Timber.w("getBrokenDirectory() mkdirs on %s failed", ankidroidDir)
             }
@@ -253,30 +253,30 @@ open class BackupManager {
          * @return whether the repair was successful
          */
         fun repairCollection(col: Collection): Boolean {
-            val deckPath = col.path
-            val deckFile = File(deckPath)
+            val colPath = col.path
+            val colFile = File(colPath)
             val time = TimeManager.time
             Timber.i("BackupManager - RepairCollection - Closing Collection")
             col.close()
 
             // repair file
-            val execString = "sqlite3 $deckPath .dump | sqlite3 $deckPath.tmp"
+            val execString = "sqlite3 $colPath .dump | sqlite3 $colPath.tmp"
             Timber.i("repairCollection - Execute: %s", execString)
             try {
                 val cmd = arrayOf("/system/bin/sh", "-c", execString)
                 val process = Runtime.getRuntime().exec(cmd)
                 process.waitFor()
-                if (!File("$deckPath.tmp").exists()) {
-                    Timber.e("repairCollection - dump to %s.tmp failed", deckPath)
+                if (!File("$colPath.tmp").exists()) {
+                    Timber.e("repairCollection - dump to %s.tmp failed", colPath)
                     return false
                 }
-                if (!moveDatabaseToBrokenDirectory(deckPath, false, time)) {
+                if (!moveDatabaseToBrokenDirectory(colPath, false, time)) {
                     Timber.e("repairCollection - could not move corrupt file to broken directory")
                     return false
                 }
                 Timber.i("repairCollection - moved corrupt file to broken directory")
-                val repairedFile = File("$deckPath.tmp")
-                return repairedFile.renameTo(deckFile)
+                val repairedFile = File("$colPath.tmp")
+                return repairedFile.renameTo(colFile)
             } catch (e: IOException) {
                 Timber.e(e, "repairCollection - error")
             } catch (e: InterruptedException) {
@@ -314,11 +314,11 @@ open class BackupManager {
             }
             if (moveConnectedFilesToo) {
                 // move all connected files (like journals, directories...) too
-                val deckName = colFile.name
+                val colName = colFile.name
                 val directory = File(colFile.parent!!)
                 for (f in directory.listFiles()!!) {
-                    if (f.name.startsWith(deckName) &&
-                        !f.renameTo(File(getBrokenDirectory(colFile.parentFile!!), f.name.replace(deckName, movedFilename)))
+                    if (f.name.startsWith(colName) &&
+                        !f.renameTo(File(getBrokenDirectory(colFile.parentFile!!), f.name.replace(colName, movedFilename)))
                     ) {
                         return false
                     }
@@ -403,16 +403,16 @@ open class BackupManager {
          * @param colPath Path of collection file whose backups should be deleted
          * @param keepNumber How many files to keep
          */
-        fun deleteDeckBackups(colPath: String, keepNumber: Int): Boolean {
-            return deleteDeckBackups(getBackups(File(colPath)), keepNumber)
+        fun deleteColBackups(colPath: String, keepNumber: Int): Boolean {
+            return deleteColBackups(getBackups(File(colPath)), keepNumber)
         }
 
-        private fun deleteDeckBackups(backups: Array<File>, keepNumber: Int): Boolean {
+        private fun deleteColBackups(backups: Array<File>, keepNumber: Int): Boolean {
             for (i in 0 until backups.size - keepNumber) {
                 if (!backups[i].delete()) {
-                    Timber.e("deleteDeckBackups() failed to delete %s", backups[i].absolutePath)
+                    Timber.e("deleteColBackups() failed to delete %s", backups[i].absolutePath)
                 } else {
-                    Timber.i("deleteDeckBackups: backup file %s deleted.", backups[i].absolutePath)
+                    Timber.i("deleteColBackups: backup file %s deleted.", backups[i].absolutePath)
                 }
             }
             return true

--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.kt
@@ -270,14 +270,14 @@ open class CardBrowser :
             if (mOrder == 0) {
                 // if the sort value in the card browser was changed, then perform a new search
                 col.set_config("sortType", fSortTypes[1])
-                AnkiDroidApp.getSharedPrefs(baseContext).edit()
-                    .putBoolean("cardBrowserNoSorting", true)
-                    .apply()
+                AnkiDroidApp.getSharedPrefs(baseContext).edit {
+                    putBoolean("cardBrowserNoSorting", true)
+                }
             } else {
                 col.set_config("sortType", fSortTypes[mOrder])
-                AnkiDroidApp.getSharedPrefs(baseContext).edit()
-                    .putBoolean("cardBrowserNoSorting", false)
-                    .apply()
+                AnkiDroidApp.getSharedPrefs(baseContext).edit {
+                    putBoolean("cardBrowserNoSorting", false)
+                }
             }
             col.set_config("sortBackwards", mOrderAsc)
             searchCards()
@@ -490,7 +490,9 @@ open class CardBrowser :
             clearLastDeckId()
             return
         }
-        getSharedPreferences(PERSISTENT_STATE_FILE, 0).edit().putLong(LAST_DECK_ID_KEY, id).apply()
+        getSharedPreferences(PERSISTENT_STATE_FILE, 0).edit {
+            putLong(LAST_DECK_ID_KEY, id)
+        }
     }
 
     override fun onCreate(savedInstanceState: Bundle?) {
@@ -586,8 +588,9 @@ open class CardBrowser :
                 // If a new column was selected then change the key used to map from mCards to the column TextView
                 if (pos != mColumn1Index) {
                     mColumn1Index = pos
-                    AnkiDroidApp.getSharedPrefs(AnkiDroidApp.instance.baseContext).edit()
-                        .putInt("cardBrowserColumn1", mColumn1Index).apply()
+                    AnkiDroidApp.getSharedPrefs(AnkiDroidApp.instance.baseContext).edit {
+                        putInt("cardBrowserColumn1", mColumn1Index)
+                    }
                     val fromMap = cardsAdapter!!.fromMapping
                     fromMap[0] = COLUMN1_KEYS[mColumn1Index]
                     cardsAdapter!!.fromMapping = fromMap
@@ -615,8 +618,9 @@ open class CardBrowser :
                 // If a new column was selected then change the key used to map from mCards to the column TextView
                 if (pos != mColumn2Index) {
                     mColumn2Index = pos
-                    AnkiDroidApp.getSharedPrefs(AnkiDroidApp.instance.baseContext).edit()
-                        .putInt("cardBrowserColumn2", mColumn2Index).apply()
+                    AnkiDroidApp.getSharedPrefs(AnkiDroidApp.instance.baseContext).edit {
+                        putInt("cardBrowserColumn2", mColumn2Index)
+                    }
                     val fromMap = cardsAdapter!!.fromMapping
                     fromMap[1] = COLUMN2_KEYS[mColumn2Index]
                     cardsAdapter!!.fromMapping = fromMap
@@ -2717,7 +2721,9 @@ open class CardBrowser :
         @KotlinCleanup(".edit { }")
         fun clearLastDeckId() {
             val context: Context = AnkiDroidApp.instance
-            context.getSharedPreferences(PERSISTENT_STATE_FILE, 0).edit().remove(LAST_DECK_ID_KEY).apply()
+            context.getSharedPreferences(PERSISTENT_STATE_FILE, 0).edit {
+                remove(LAST_DECK_ID_KEY)
+            }
         }
 
         private fun getPositionMap(cards: CardCollection<CardCache>): Map<Long, Int> {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/CrashReportService.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CrashReportService.kt
@@ -168,24 +168,24 @@ object CrashReportService {
      * @param value value of FEEDBACK_REPORT_KEY preference
      */
     fun setAcraReportingMode(value: String) {
-        val editor = AnkiDroidApp.getSharedPrefs(mApplication).edit()
-        // Set the ACRA disable value
-        if (value == FEEDBACK_REPORT_NEVER) {
-            editor.putBoolean(ACRA.PREF_DISABLE_ACRA, true)
-        } else {
-            editor.putBoolean(ACRA.PREF_DISABLE_ACRA, false)
-            // Switch between auto-report via toast and manual report via dialog
-            if (value == FEEDBACK_REPORT_ALWAYS) {
-                dialogEnabled = false
-                toastText = mApplication.getString(R.string.feedback_auto_toast_text)
-            } else if (value == FEEDBACK_REPORT_ASK) {
+        AnkiDroidApp.getSharedPrefs(mApplication).edit {
+            // Set the ACRA disable value
+            if (value == FEEDBACK_REPORT_NEVER) {
+                putBoolean(ACRA.PREF_DISABLE_ACRA, true)
+            } else {
+                putBoolean(ACRA.PREF_DISABLE_ACRA, false)
+                // Switch between auto-report via toast and manual report via dialog
+                if (value == FEEDBACK_REPORT_ALWAYS) {
+                    dialogEnabled = false
+                    toastText = mApplication.getString(R.string.feedback_auto_toast_text)
+                } else if (value == FEEDBACK_REPORT_ASK) {
+                    createAcraCoreConfigBuilder()
+                    dialogEnabled = true
+                    toastText = mApplication.getString(R.string.feedback_for_manual_toast_text)
+                }
                 createAcraCoreConfigBuilder()
-                dialogEnabled = true
-                toastText = mApplication.getString(R.string.feedback_for_manual_toast_text)
             }
-            createAcraCoreConfigBuilder()
         }
-        editor.apply()
     }
 
     /**

--- a/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.kt
@@ -1352,7 +1352,7 @@ open class DeckPicker :
      */
     override fun showSyncErrorDialog(dialogType: Int, message: String?) {
         val newFragment: AsyncDialogFragment = newInstance(dialogType, message)
-        showAsyncDialogFragment(newFragment, NotificationChannels.Channel.SYNC)
+        showAsyncDialogFragment(newFragment, Channel.SYNC)
     }
 
     /**
@@ -1374,7 +1374,7 @@ open class DeckPicker :
             showSimpleNotification(
                 res.getString(R.string.app_name),
                 res.getString(messageResource),
-                NotificationChannels.Channel.SYNC
+                Channel.SYNC
             )
         } else {
             if (syncMessage.isNullOrEmpty()) {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.kt
@@ -953,13 +953,12 @@ open class DeckPicker :
 
         // Check whether the option is selected, the user is signed in, last sync was AUTOMATIC_SYNC_TIME ago
         // (currently 10 minutes), and is not under a metered connection (if not allowed by preference)
-        val isLoggedIn = preferences.getString("hkey", "")!!.isNotEmpty()
         val lastSyncTime = preferences.getLong("lastSyncTime", 0)
         val autoSyncIsEnabled = preferences.getBoolean("automaticSyncMode", false)
         val syncIntervalPassed = TimeManager.time.intTimeMS() - lastSyncTime > AUTOMATIC_SYNC_MIN_INTERVAL
         val isNotBlockedByMeteredConnection = preferences.getBoolean(getString(R.string.metered_sync_key), false) || !isActiveNetworkMetered()
 
-        if (isLoggedIn && autoSyncIsEnabled && NetworkUtils.isOnline && syncIntervalPassed && isNotBlockedByMeteredConnection) {
+        if (SyncStatus.isLoggedIn && autoSyncIsEnabled && NetworkUtils.isOnline && syncIntervalPassed && isNotBlockedByMeteredConnection) {
             Timber.i("Triggering Automatic Sync")
             sync()
         }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.kt
@@ -1128,8 +1128,7 @@ open class DeckPicker :
                 // Fresh install
                 current
             }
-            preferences.edit().putLong(UPGRADE_VERSION_KEY, current).apply()
-
+            preferences.edit { putLong(UPGRADE_VERSION_KEY, current) }
             // Delete the media database made by any version before 2.3 beta due to upgrade errors.
             // It is rebuilt on the next sync or media check
             if (previous < 20300200) {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.kt
@@ -275,7 +275,7 @@ open class DeckPicker :
     private val mImportAddListener = ImportAddListener(this)
 
     @KotlinCleanup("Migrate from Triple to Kotlin class")
-    private class ImportAddListener(deckPicker: DeckPicker?) : TaskListenerWithContext<DeckPicker, String, Triple<List<AnkiPackageImporter>?, Boolean, String?>?>(deckPicker) {
+    private class ImportAddListener(deckPicker: DeckPicker) : TaskListenerWithContext<DeckPicker, String, Triple<List<AnkiPackageImporter>?, Boolean, String?>?>(deckPicker) {
         override fun actualOnPostExecute(context: DeckPicker, result: Triple<List<AnkiPackageImporter>?, Boolean, String?>?) {
             if (context.mProgressDialog != null && context.mProgressDialog!!.isShowing) {
                 context.mProgressDialog!!.dismiss()
@@ -336,7 +336,7 @@ open class DeckPicker :
         return ImportReplaceListener(this)
     }
 
-    private class ImportReplaceListener(deckPicker: DeckPicker?) : TaskListenerWithContext<DeckPicker, String, Computation<*>?>(deckPicker) {
+    private class ImportReplaceListener(deckPicker: DeckPicker) : TaskListenerWithContext<DeckPicker, String, Computation<*>?>(deckPicker) {
         override fun actualOnPostExecute(context: DeckPicker, result: Computation<*>?) {
             Timber.i("Import: Replace Task Completed")
             if (context.mProgressDialog != null && context.mProgressDialog!!.isShowing) {
@@ -1286,7 +1286,7 @@ open class DeckPicker :
         return UndoTaskListener(isReview, this)
     }
 
-    private class UndoTaskListener(private val isReview: Boolean, deckPicker: DeckPicker?) : TaskListenerWithContext<DeckPicker, Unit, Computation<NextCard<*>>?>(deckPicker) {
+    private class UndoTaskListener(private val isReview: Boolean, deckPicker: DeckPicker) : TaskListenerWithContext<DeckPicker, Unit, Computation<NextCard<*>>?>(deckPicker) {
         override fun actualOnCancelled(context: DeckPicker) {
             context.hideProgressBar()
         }
@@ -2138,7 +2138,7 @@ open class DeckPicker :
         return UpdateDeckListListener(this)
     }
 
-    private class UpdateDeckListListener<T : AbstractDeckTreeNode>(private val deckPicker: DeckPicker?) : TaskListenerWithContext<DeckPicker, Void, List<TreeNode<T>>?>(deckPicker) {
+    private class UpdateDeckListListener<T : AbstractDeckTreeNode>(deckPicker: DeckPicker) : TaskListenerWithContext<DeckPicker, Void, List<TreeNode<T>>?>(deckPicker) {
         override fun actualOnPreExecute(context: DeckPicker) {
             if (!context.colIsOpen()) {
                 context.showProgressBar()

--- a/AnkiDroid/src/main/java/com/ichi2/anki/InitialActivity.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/InitialActivity.kt
@@ -19,6 +19,7 @@ package com.ichi2.anki
 import android.content.Context
 import android.content.SharedPreferences
 import androidx.annotation.CheckResult
+import androidx.core.content.edit
 import com.ichi2.anki.servicelayer.PreferenceUpgradeService
 import com.ichi2.anki.servicelayer.PreferenceUpgradeService.setPreferencesUpToDate
 import com.ichi2.utils.VersionUtils.pkgVersionName
@@ -97,7 +98,7 @@ object InitialActivity {
     /** Sets the preference stating that the latest version has been applied  */
     fun setUpgradedToLatestVersion(preferences: SharedPreferences) {
         Timber.i("Marked prefs as upgraded to latest version: %s", pkgVersionName)
-        preferences.edit().putString("lastVersion", pkgVersionName).apply()
+        preferences.edit { putString("lastVersion", pkgVersionName) }
     }
 
     /** @return false: The app has been upgraded since the last launch OR the app was launched for the first time.

--- a/AnkiDroid/src/main/java/com/ichi2/anki/MyAccount.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/MyAccount.kt
@@ -37,9 +37,9 @@ import com.ichi2.themes.StyledProgressDialog
 import com.ichi2.ui.TextInputEditField
 import com.ichi2.utils.AdaptionUtil.isUserATestClient
 import com.ichi2.utils.KotlinCleanup
+import com.ichi2.utils.SyncStatus
 import net.ankiweb.rsdroid.BackendFactory
 import timber.log.Timber
-import java.lang.Exception
 import java.net.UnknownHostException
 
 /**
@@ -90,8 +90,7 @@ open class MyAccount : AnkiActivity() {
         }
         mayOpenUrl(Uri.parse(resources.getString(R.string.register_url)))
         initAllContentViews()
-        val preferences = AnkiDroidApp.getSharedPrefs(baseContext)
-        if (preferences.getString("hkey", "")!!.isNotEmpty()) {
+        if (SyncStatus.isLoggedIn) {
             switchToState(STATE_LOGGED_IN)
         } else {
             switchToState(STATE_LOG_IN)

--- a/AnkiDroid/src/main/java/com/ichi2/anki/NavigationDrawerActivity.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/NavigationDrawerActivity.kt
@@ -44,13 +44,13 @@ import com.ichi2.anim.ActivityTransitionAnimation.Direction.*
 import com.ichi2.anki.dialogs.HelpDialog
 import com.ichi2.anki.preferences.Preferences
 import com.ichi2.anki.workarounds.FullDraggableContainerFix
+import com.ichi2.compat.CompatHelper
 import com.ichi2.libanki.CardId
 import com.ichi2.themes.Themes
 import com.ichi2.utils.HandlerUtils
 import com.ichi2.utils.KotlinCleanup
 import net.ankiweb.rsdroid.BackendFactory
 import timber.log.Timber
-import java.util.*
 
 @KotlinCleanup("lateinit if possible")
 @KotlinCleanup("IDE-lint")
@@ -235,7 +235,7 @@ abstract class NavigationDrawerActivity :
     private val mPreferencesLauncher = registerForActivityResult(ActivityResultContracts.StartActivityForResult()) { result ->
         val preferences = preferences
         Timber.i("Handling Activity Result: %d. Result: %d", REQUEST_PREFERENCES_UPDATE, result.resultCode)
-        NotificationChannels.setup(applicationContext)
+        CompatHelper.compat.setupNotificationChannel(applicationContext)
         // Restart the activity on preference change
         // collection path hasn't been changed so just restart the current activity
         if (this is Reviewer && preferences.getBoolean("tts", false)) {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.kt
@@ -44,6 +44,7 @@ import androidx.annotation.VisibleForTesting
 import androidx.appcompat.view.menu.MenuBuilder
 import androidx.appcompat.widget.AppCompatButton
 import androidx.appcompat.widget.PopupMenu
+import androidx.core.content.edit
 import androidx.core.content.res.ResourcesCompat
 import androidx.core.text.HtmlCompat
 import com.afollestad.materialdialogs.MaterialDialog
@@ -917,8 +918,9 @@ class NoteEditor : AnkiActivity(), DeckSelectionListener, SubtitleListener, Tags
             }
             R.id.action_show_toolbar -> {
                 item.isChecked = !item.isChecked
-                AnkiDroidApp.getSharedPrefs(this).edit()
-                    .putBoolean(PREF_NOTE_EDITOR_SHOW_TOOLBAR, item.isChecked).apply()
+                AnkiDroidApp.getSharedPrefs(this).edit {
+                    putBoolean(PREF_NOTE_EDITOR_SHOW_TOOLBAR, item.isChecked)
+                }
                 updateToolbar()
             }
             R.id.action_capitalize -> {
@@ -929,8 +931,9 @@ class NoteEditor : AnkiActivity(), DeckSelectionListener, SubtitleListener, Tags
             }
             R.id.action_scroll_toolbar -> {
                 item.isChecked = !item.isChecked
-                AnkiDroidApp.getSharedPrefs(this).edit()
-                    .putBoolean(PREF_NOTE_EDITOR_SCROLL_TOOLBAR, item.isChecked).apply()
+                AnkiDroidApp.getSharedPrefs(this).edit {
+                    putBoolean(PREF_NOTE_EDITOR_SCROLL_TOOLBAR, item.isChecked)
+                }
                 updateToolbar()
             }
         }
@@ -938,7 +941,9 @@ class NoteEditor : AnkiActivity(), DeckSelectionListener, SubtitleListener, Tags
     }
 
     private fun toggleCapitalize(value: Boolean) {
-        AnkiDroidApp.getSharedPrefs(this).edit().putBoolean(PREF_NOTE_EDITOR_CAPITALIZE, value).apply()
+        AnkiDroidApp.getSharedPrefs(this).edit {
+            putBoolean(PREF_NOTE_EDITOR_CAPITALIZE, value)
+        }
         for (f in mEditFields!!) {
             f!!.setCapitalize(value)
         }
@@ -949,7 +954,7 @@ class NoteEditor : AnkiActivity(), DeckSelectionListener, SubtitleListener, Tags
             return
         }
         Timber.i("Setting font size to %d", fontSizeSp)
-        AnkiDroidApp.getSharedPrefs(this).edit().putInt(PREF_NOTE_EDITOR_FONT_SIZE, fontSizeSp).apply()
+        AnkiDroidApp.getSharedPrefs(this).edit { putInt(PREF_NOTE_EDITOR_FONT_SIZE, fontSizeSp) }
         for (f in mEditFields!!) {
             f!!.textSize = fontSizeSp.toFloat()
         }
@@ -1746,9 +1751,9 @@ class NoteEditor : AnkiActivity(), DeckSelectionListener, SubtitleListener, Tags
         }
 
     private fun saveToolbarButtons(buttons: ArrayList<CustomToolbarButton>) {
-        AnkiDroidApp.getSharedPrefs(this).edit()
-            .putStringSet(PREF_NOTE_EDITOR_CUSTOM_BUTTONS, CustomToolbarButton.toStringSet(buttons))
-            .apply()
+        AnkiDroidApp.getSharedPrefs(this).edit {
+            putStringSet(PREF_NOTE_EDITOR_CUSTOM_BUTTONS, CustomToolbarButton.toStringSet(buttons))
+        }
     }
 
     private fun addToolbarButton(buttonText: String, prefix: String, suffix: String) {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/NotificationChannels.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/NotificationChannels.kt
@@ -17,33 +17,60 @@
 
 package com.ichi2.anki
 
+import android.annotation.TargetApi
+import android.app.NotificationChannel
+import android.app.NotificationManager
 import android.content.Context
 import android.content.res.Resources
+import android.os.Build
 import androidx.annotation.StringRes
-import com.ichi2.compat.CompatHelper
+import androidx.core.app.NotificationCompat
+import timber.log.Timber
 
 object NotificationChannels {
 
     /**
      * Create or update all the notification channels for the app
      *
+     * In Oreo and higher, you must create a channel for all notifications.
+     * This will create the channel if it doesn't exist, or if it exists it will update the name.
+     *
+     * Note that once a channel is created, only the name may be changed as long as the application
+     * is installed on the user device. All other settings are fully under user control.
+
      * TODO should be called in response to {@link android.content.Intent#ACTION_LOCALE_CHANGED}
      * @param context the context for access to localized strings for channel names
      */
+    @TargetApi(26)
     fun setup(context: Context) {
         val res = context.resources
-        val compat = CompatHelper.compat
         for (channel in Channel.values()) {
-            compat.setupNotificationChannel(context, channel.id, channel.getName(res))
+            val id = channel.id
+            val name = channel.getName(res)
+            val importance = channel.importance()
+            Timber.i("Creating notification channel with id/name: %s/%s", id, name)
+            val manager = context.getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
+            val notificationChannel = NotificationChannel(id, name, importance)
+            notificationChannel.setShowBadge(true)
+            notificationChannel.lockscreenVisibility = NotificationCompat.VISIBILITY_PUBLIC
+            manager.createNotificationChannel(notificationChannel)
         }
     }
+}
 
-    enum class Channel(val id: String, @StringRes val nameId: Int) {
-        GENERAL("General Notifications", R.string.app_name),
-        SYNC("Synchronization", R.string.sync_title),
-        GLOBAL_REMINDERS("Global Reminders", R.string.widget_minimum_cards_due_notification_ticker_title),
-        DECK_REMINDERS("Deck Reminders", R.string.deck_conf_reminders);
+/**
+ * The importance of this channel.
+ */
+// Not in the enum, as otherwise the enum values could only be accessed starting at API N.
+@TargetApi(Build.VERSION_CODES.N)
+fun Channel.importance() =
+    if (this == Channel.SCOPED_STORAGE_MIGRATION) NotificationManager.IMPORTANCE_LOW else NotificationManager.IMPORTANCE_DEFAULT
 
-        fun getName(res: Resources) = res.getString(nameId)
-    }
+enum class Channel(val id: String, @StringRes val nameId: Int) {
+    GENERAL("General Notifications", R.string.app_name),
+    SYNC("Synchronization", R.string.sync_title),
+    GLOBAL_REMINDERS("Global Reminders", R.string.widget_minimum_cards_due_notification_ticker_title),
+    DECK_REMINDERS("Deck Reminders", R.string.deck_conf_reminders),
+    SCOPED_STORAGE_MIGRATION("Scoped Storage", R.string.scoped_storage_title) ;
+    fun getName(res: Resources) = res.getString(nameId)
 }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/OnboardingUtils.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/OnboardingUtils.kt
@@ -23,7 +23,6 @@ import androidx.core.content.edit
 import com.ichi2.anki.IntroductionActivity.Companion.INTRODUCTION_SLIDES_SHOWN
 import timber.log.Timber
 import java.util.*
-import kotlin.collections.HashSet
 
 class OnboardingUtils {
 
@@ -73,7 +72,7 @@ class OnboardingUtils {
             // Set the bit at the index defined for a feature once the tutorial for that feature is seen by the user.
             visitedFeatures.set(featureIdentifier.getOnboardingEnumValue())
 
-            AnkiDroidApp.getSharedPrefs(context).edit().putLong(featureIdentifier.getFeatureConstant(), visitedFeatures.toLongArray()[0]).apply()
+            AnkiDroidApp.getSharedPrefs(context).edit { putLong(featureIdentifier.getFeatureConstant(), visitedFeatures.toLongArray()[0]) }
         }
 
         /**

--- a/AnkiDroid/src/main/java/com/ichi2/anki/Whiteboard.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/Whiteboard.kt
@@ -31,6 +31,7 @@ import android.widget.LinearLayout
 import androidx.annotation.CheckResult
 import androidx.annotation.VisibleForTesting
 import androidx.core.content.ContextCompat
+import androidx.core.content.edit
 import com.ichi2.anki.dialogs.WhiteBoardWidthDialog
 import com.ichi2.compat.CompatHelper
 import com.ichi2.libanki.utils.Time
@@ -373,9 +374,9 @@ class Whiteboard(activity: AnkiActivity, handleMultiTouch: Boolean, inverted: Bo
 
     private fun saveStrokeWidth(wbStrokeWidth: Int) {
         mPaint.strokeWidth = wbStrokeWidth.toFloat()
-        val edit = AnkiDroidApp.getSharedPrefs(mAnkiActivity).edit()
-        edit.putInt("whiteBoardStrokeWidth", wbStrokeWidth)
-        edit.apply()
+        AnkiDroidApp.getSharedPrefs(mAnkiActivity).edit {
+            putInt("whiteBoardStrokeWidth", wbStrokeWidth)
+        }
     }
 
     @get:VisibleForTesting

--- a/AnkiDroid/src/main/java/com/ichi2/anki/analytics/AnkiDroidCrashReportDialog.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/analytics/AnkiDroidCrashReportDialog.kt
@@ -24,6 +24,7 @@ import android.os.Bundle
 import android.view.View
 import android.widget.CheckBox
 import android.widget.EditText
+import androidx.core.content.edit
 import com.ichi2.anki.AnkiDroidApp
 import com.ichi2.anki.CrashReportService
 import com.ichi2.anki.R
@@ -85,10 +86,10 @@ class AnkiDroidCrashReportDialog : CrashReportDialog(), DialogInterface.OnClickL
             // Next time don't tick the auto-report checkbox by default
             val autoReport = mAlwaysReportCheckBox!!.isChecked
             val preferences = AnkiDroidApp.getSharedPrefs(this)
-            preferences.edit().putBoolean("autoreportCheckboxValue", autoReport).apply()
+            preferences.edit { putBoolean("autoreportCheckboxValue", autoReport) }
             // Set the autoreport value to true if ticked
             if (autoReport) {
-                preferences.edit().putString(CrashReportService.FEEDBACK_REPORT_KEY, CrashReportService.FEEDBACK_REPORT_ALWAYS).apply()
+                preferences.edit { putString(CrashReportService.FEEDBACK_REPORT_KEY, CrashReportService.FEEDBACK_REPORT_ALWAYS) }
                 CrashReportService.setAcraReportingMode(CrashReportService.FEEDBACK_REPORT_ALWAYS)
             }
             // Send the crash report

--- a/AnkiDroid/src/main/java/com/ichi2/anki/analytics/UsageAnalytics.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/analytics/UsageAnalytics.kt
@@ -21,6 +21,7 @@ import android.content.SharedPreferences
 import android.os.Build
 import android.webkit.WebSettings
 import androidx.annotation.VisibleForTesting
+import androidx.core.content.edit
 import com.brsanthu.googleanalytics.GoogleAnalytics
 import com.brsanthu.googleanalytics.GoogleAnalyticsConfig
 import com.brsanthu.googleanalytics.httpclient.OkHttpClientImpl
@@ -34,7 +35,6 @@ import com.ichi2.utils.WebViewDebugging.hasSetDataDirectory
 import org.acra.ACRA
 import org.acra.util.Installation
 import timber.log.Timber
-import java.lang.RuntimeException
 
 @KotlinCleanup("see if we can make variables lazy, or properties without the `s` prefix")
 object UsageAnalytics {
@@ -296,9 +296,9 @@ object UsageAnalytics {
         }
         set(value) {
             // A listener on this preference handles the rest
-            AnkiDroidApp.getSharedPrefs(AnkiDroidApp.instance).edit()
-                .putBoolean(ANALYTICS_OPTIN_KEY, value)
-                .apply()
+            AnkiDroidApp.getSharedPrefs(AnkiDroidApp.instance).edit {
+                putBoolean(ANALYTICS_OPTIN_KEY, value)
+            }
         }
 
     @VisibleForTesting(otherwise = VisibleForTesting.NONE)

--- a/AnkiDroid/src/main/java/com/ichi2/anki/cardviewer/ViewerCommand.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/cardviewer/ViewerCommand.kt
@@ -107,7 +107,7 @@ enum class ViewerCommand(val resourceId: Int) {
         val bindings: MutableList<MappableBinding> = fromPreference(preferences, this)
         performAdd.apply(bindings, binding)
         val newValue: String = bindings.toPreferenceString()
-        preferences.edit().putString(preferenceKey, newValue).apply()
+        preferences.edit { putString(preferenceKey, newValue) }
     }
 
     fun removeBinding(prefs: SharedPreferences, binding: MappableBinding) {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/DatabaseErrorDialog.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/DatabaseErrorDialog.kt
@@ -369,7 +369,7 @@ class DatabaseErrorDialog : AsyncDialogFragment() {
                 res().getString(R.string.access_collection_failed_message, res().getString(R.string.link_help))
             }
             DIALOG_DB_ERROR -> res().getString(R.string.answering_error_message)
-            DIALOG_REPAIR_COLLECTION -> res().getString(R.string.repair_deck_dialog, BackupManager.BROKEN_DECKS_SUFFIX)
+            DIALOG_REPAIR_COLLECTION -> res().getString(R.string.repair_deck_dialog, BackupManager.BROKEN_COLLECTIONS_SUFFIX)
             DIALOG_RESTORE_BACKUP -> res().getString(R.string.backup_restore_no_backups)
             DIALOG_NEW_COLLECTION -> res().getString(R.string.backup_del_collection_question)
             DIALOG_CONFIRM_DATABASE_CHECK -> res().getString(R.string.check_db_warning)

--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/DialogHandler.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/DialogHandler.kt
@@ -98,9 +98,9 @@ class DialogHandler(activity: AnkiActivity) : Handler(getDefaultLooper()) {
                     // getQuantityString needs an int
                     val remaining = min(Int.MAX_VALUE.toLong(), remainingTimeInSeconds).toInt()
                     val message = res.getQuantityString(R.plurals.sync_automatic_sync_needs_more_time, remaining, remaining)
-                    mActivity.get()!!.showSimpleNotification(err, message, NotificationChannels.Channel.SYNC)
+                    mActivity.get()!!.showSimpleNotification(err, message, Channel.SYNC)
                 } else {
-                    mActivity.get()!!.showSimpleNotification(err, res.getString(R.string.youre_offline), NotificationChannels.Channel.SYNC)
+                    mActivity.get()!!.showSimpleNotification(err, res.getString(R.string.youre_offline), Channel.SYNC)
                 }
             }
             mActivity.get()!!.finishWithoutAnimation()

--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/customstudy/CustomStudyDialog.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/customstudy/CustomStudyDialog.kt
@@ -30,6 +30,7 @@ import android.widget.EditText
 import android.widget.TextView
 import androidx.annotation.StringRes
 import androidx.annotation.VisibleForTesting
+import androidx.core.content.edit
 import androidx.fragment.app.DialogFragment
 import com.afollestad.materialdialogs.MaterialDialog
 import com.afollestad.materialdialogs.WhichButton
@@ -207,7 +208,7 @@ class CustomStudyDialog(private val collection: Collection, private val customSt
                 }
                 when (contextMenuOption) {
                     STUDY_NEW -> {
-                        AnkiDroidApp.getSharedPrefs(requireActivity()).edit().putInt("extendNew", n).apply()
+                        AnkiDroidApp.getSharedPrefs(requireActivity()).edit { putInt("extendNew", n) }
                         val deck = collection.decks.get(did)
                         deck.put("extendNew", n)
                         collection.decks.save(deck)
@@ -215,7 +216,7 @@ class CustomStudyDialog(private val collection: Collection, private val customSt
                         onLimitsExtended(jumpToReviewer)
                     }
                     STUDY_REV -> {
-                        AnkiDroidApp.getSharedPrefs(requireActivity()).edit().putInt("extendRev", n).apply()
+                        AnkiDroidApp.getSharedPrefs(requireActivity()).edit { putInt("extendRev", n) }
                         val deck = collection.decks.get(did)
                         deck.put("extendRev", n)
                         collection.decks.save(deck)

--- a/AnkiDroid/src/main/java/com/ichi2/anki/export/ActivityExportingDelegate.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/export/ActivityExportingDelegate.kt
@@ -15,6 +15,7 @@
  */
 package com.ichi2.anki.export
 
+import android.app.Activity
 import android.content.ClipData
 import android.content.Intent
 import android.net.Uri
@@ -283,6 +284,12 @@ class ActivityExportingDelegate(private val activity: AnkiActivity, private val 
         fragmentManager.fragmentFactory = mDialogsFactory
         mSaveFileLauncher = activity.registerForActivityResult(
             ActivityResultContracts.StartActivityForResult()
-        ) { result: ActivityResult -> saveFileCallback(result) }
+        ) { result: ActivityResult ->
+            if (result.resultCode == Activity.RESULT_OK) {
+                saveFileCallback(result)
+            } else {
+                Timber.i("The file selection for the exported collection was cancelled")
+            }
+        }
     }
 }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/export/ExportListener.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/export/ExportListener.kt
@@ -22,7 +22,8 @@ import com.ichi2.async.TaskListenerWithContext
 import com.ichi2.themes.StyledProgressDialog
 import timber.log.Timber
 
-internal class ExportListener(activity: AnkiActivity?, private val dialogsFactory: ExportDialogsFactory) : TaskListenerWithContext<AnkiActivity, Void, Pair<Boolean, String?>?>(activity) {
+internal class ExportListener(activity: AnkiActivity, private val dialogsFactory: ExportDialogsFactory) :
+    TaskListenerWithContext<AnkiActivity, Void, Pair<Boolean, String?>?>(activity) {
     @Suppress("Deprecation")
     private var mProgressDialog: android.app.ProgressDialog? = null
     override fun actualOnPreExecute(context: AnkiActivity) {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/reviewer/FullScreenMode.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/reviewer/FullScreenMode.kt
@@ -16,6 +16,7 @@
 package com.ichi2.anki.reviewer
 
 import android.content.SharedPreferences
+import androidx.core.content.edit
 import timber.log.Timber
 
 /** Whether Reviewer content should take the full screen */
@@ -51,12 +52,14 @@ enum class FullScreenMode(private val prefValue: String) {
             val fullScreenModeKey = PREF_KEY
             val old = preferences.getBoolean("fullscreenReview", false)
             val newValue = if (old) BUTTONS_ONLY else BUTTONS_AND_MENU
-            preferences.edit().putString(fullScreenModeKey, newValue.getPreferenceValue()).apply()
-            preferences.edit().remove("fullscreenReview").apply()
+            preferences.edit {
+                putString(fullScreenModeKey, newValue.getPreferenceValue())
+                remove("fullscreenReview")
+            }
         }
 
         fun setPreference(prefs: SharedPreferences, mode: FullScreenMode) {
-            prefs.edit().putString(PREF_KEY, mode.getPreferenceValue()).apply()
+            prefs.edit { putString(PREF_KEY, mode.getPreferenceValue()) }
         }
     }
 }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/services/NotificationService.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/services/NotificationService.kt
@@ -23,8 +23,8 @@ import android.graphics.Color
 import androidx.core.app.NotificationCompat
 import androidx.core.content.ContextCompat
 import com.ichi2.anki.AnkiDroidApp
+import com.ichi2.anki.Channel
 import com.ichi2.anki.DeckPicker
-import com.ichi2.anki.NotificationChannels
 import com.ichi2.anki.R
 import com.ichi2.anki.preferences.Preferences
 import com.ichi2.compat.CompatHelper
@@ -51,7 +51,7 @@ class NotificationService : BroadcastReceiver() {
                 // The NotificationCompat code uses setSound() no matter what we do and triggers it.
                 val builder = NotificationCompat.Builder(
                     context,
-                    NotificationChannels.Channel.GENERAL.id
+                    Channel.GENERAL.id
                 )
                     .setCategory(NotificationCompat.CATEGORY_REMINDER)
                     .setSmallIcon(R.drawable.ic_stat_notify)

--- a/AnkiDroid/src/main/java/com/ichi2/anki/services/ReminderService.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/services/ReminderService.kt
@@ -22,9 +22,9 @@ import android.content.Intent
 import androidx.core.app.NotificationCompat
 import androidx.core.app.NotificationManagerCompat
 import androidx.core.content.ContextCompat
+import com.ichi2.anki.Channel
 import com.ichi2.anki.CollectionHelper
 import com.ichi2.anki.IntentHandler
-import com.ichi2.anki.NotificationChannels
 import com.ichi2.anki.R
 import com.ichi2.compat.CompatHelper
 import com.ichi2.libanki.Collection
@@ -103,7 +103,7 @@ class ReminderService : BroadcastReceiver() {
             Timber.v("onReceive - deck '%s' due count %d", deckDue.fullDeckName, total)
             val notification = NotificationCompat.Builder(
                 context,
-                NotificationChannels.Channel.DECK_REMINDERS.id
+                Channel.DECK_REMINDERS.id
             )
                 .setCategory(NotificationCompat.CATEGORY_REMINDER)
                 .setContentTitle(context.getString(R.string.reminder_title))

--- a/AnkiDroid/src/main/java/com/ichi2/async/TaskListenerWithContext.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/async/TaskListenerWithContext.kt
@@ -19,7 +19,7 @@ import java.lang.ref.WeakReference
 
 /** Similar to task listener, but if the context disappear, no action are executed.
  * We ensure that the context can't disappear during the execution of the methods. */
-abstract class TaskListenerWithContext<CTX, Progress, Result> protected constructor(context: CTX?) :
+abstract class TaskListenerWithContext<CTX, Progress, Result> protected constructor(context: CTX) :
     TaskListener<Progress, Result>() where CTX : Any {
     private val mContext: WeakReference<CTX>
     override fun onPreExecute() {

--- a/AnkiDroid/src/main/java/com/ichi2/compat/Compat.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/compat/Compat.kt
@@ -69,7 +69,7 @@ import java.io.*
  * `CompatV23` due to a change of API, need not be implemented again in CompatV26.
  */
 interface Compat {
-    fun setupNotificationChannel(context: Context, id: String, name: String)
+    fun setupNotificationChannel(context: Context)
     fun setTime(picker: TimePicker, hour: Int, minute: Int)
     fun getHour(picker: TimePicker): Int
     fun getMinute(picker: TimePicker): Int

--- a/AnkiDroid/src/main/java/com/ichi2/compat/CompatV21.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/compat/CompatV21.kt
@@ -42,7 +42,7 @@ import java.io.*
 @Suppress("Deprecation")
 open class CompatV21 : Compat {
     // Until API26, ignore notification channels
-    override fun setupNotificationChannel(context: Context, id: String, name: String) { /* pre-API26, do nothing */
+    override fun setupNotificationChannel(context: Context) { /* pre-API26, do nothing */
     }
 
     // Until API 23 the methods have "current" in the name

--- a/AnkiDroid/src/main/java/com/ichi2/compat/CompatV26.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/compat/CompatV26.kt
@@ -17,8 +17,6 @@
 package com.ichi2.compat
 
 import android.annotation.TargetApi
-import android.app.NotificationChannel
-import android.app.NotificationManager
 import android.content.Context
 import android.media.AudioFocusRequest
 import android.media.AudioManager
@@ -26,9 +24,8 @@ import android.media.AudioManager.OnAudioFocusChangeListener
 import android.os.VibrationEffect
 import android.os.Vibrator
 import androidx.annotation.VisibleForTesting
-import androidx.core.app.NotificationCompat
+import com.ichi2.anki.NotificationChannels
 import com.ichi2.utils.KotlinCleanup
-import timber.log.Timber
 import java.io.*
 import java.nio.file.*
 
@@ -38,21 +35,9 @@ open class CompatV26 : CompatV23(), Compat {
     /**
      * In Oreo and higher, you must create a channel for all notifications.
      * This will create the channel if it doesn't exist, or if it exists it will update the name.
-     *
-     * Note that once a channel is created, only the name may be changed as long as the application
-     * is installed on the user device. All other settings are fully under user control.
-     *
-     * @param context the Context with a handle to the NotificationManager
-     * @param id the unique (within the package) id the channel for programmatic access
-     * @param name the user-visible name for the channel
      */
-    override fun setupNotificationChannel(context: Context, id: String, name: String) {
-        Timber.i("Creating notification channel with id/name: %s/%s", id, name)
-        val manager = context.getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
-        val notificationChannel = NotificationChannel(id, name, NotificationManager.IMPORTANCE_DEFAULT)
-        notificationChannel.setShowBadge(true)
-        notificationChannel.lockscreenVisibility = NotificationCompat.VISIBILITY_PUBLIC
-        manager.createNotificationChannel(notificationChannel)
+    override fun setupNotificationChannel(context: Context) {
+        NotificationChannels.setup(context)
     }
 
     @Suppress("DEPRECATION")

--- a/AnkiDroid/src/main/java/com/ichi2/preferences/CustomDialogPreference.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/preferences/CustomDialogPreference.kt
@@ -19,6 +19,7 @@ package com.ichi2.preferences
 import android.content.Context
 import android.content.DialogInterface
 import android.util.AttributeSet
+import androidx.core.content.edit
 import com.ichi2.anki.AnkiDroidApp
 import com.ichi2.anki.R
 
@@ -27,21 +28,21 @@ import com.ichi2.anki.R
 class CustomDialogPreference(private val context_: Context, attrs: AttributeSet?) : android.preference.DialogPreference(context_, attrs), DialogInterface.OnClickListener {
     override fun onClick(dialog: DialogInterface, which: Int) {
         if (which == DialogInterface.BUTTON_POSITIVE) {
-            if (this.title == context_.resources.getString(R.string.deck_conf_reset)) {
-                // Deck Options :: Restore Defaults for Options Group
-                val editor = AnkiDroidApp.getSharedPrefs(context_).edit()
-                editor.putBoolean("confReset", true)
-                editor.commit()
-            } else if (this.title == context_.resources.getString(R.string.dialog_positive_remove)) {
-                // Deck Options :: Remove Options Group
-                val editor = AnkiDroidApp.getSharedPrefs(context_).edit()
-                editor.putBoolean("confRemove", true)
-                editor.commit()
-            } else if (this.title == context_.resources.getString(R.string.deck_conf_set_subdecks)) {
-                // Deck Options :: Set Options Group for all Sub-decks
-                val editor = AnkiDroidApp.getSharedPrefs(context_).edit()
-                editor.putBoolean("confSetSubdecks", true)
-                editor.commit()
+            AnkiDroidApp.getSharedPrefs(context_).edit(commit = true) {
+                when (title) {
+                    context_.resources.getString(R.string.deck_conf_reset) -> {
+                        // Deck Options :: Restore Defaults for Options Group
+                        putBoolean("confReset", true)
+                    }
+                    context_.resources.getString(R.string.dialog_positive_remove) -> {
+                        // Deck Options :: Remove Options Group
+                        putBoolean("confRemove", true)
+                    }
+                    context_.resources.getString(R.string.deck_conf_set_subdecks) -> {
+                        // Deck Options :: Set Options Group for all Sub-decks
+                        putBoolean("confSetSubdecks", true)
+                    }
+                }
             }
         }
     }

--- a/AnkiDroid/src/main/java/com/ichi2/preferences/PreferenceExtensions.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/preferences/PreferenceExtensions.kt
@@ -17,6 +17,7 @@ package com.ichi2.preferences
 
 import android.content.SharedPreferences
 import androidx.annotation.CheckResult
+import androidx.core.content.edit
 import java.util.function.Supplier
 
 /** Extension methods over the SharedPreferences class  */
@@ -35,7 +36,7 @@ object PreferenceExtensions {
             return target.getString(key, "")!!
         }
         val supplied = supplier.get()
-        target.edit().putString(key, supplied).apply()
+        target.edit { putString(key, supplied) }
         return supplied
     }
 }

--- a/AnkiDroid/src/main/java/com/ichi2/utils/SyncStatus.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/utils/SyncStatus.kt
@@ -17,6 +17,7 @@
 package com.ichi2.utils
 
 import android.content.Context
+import androidx.core.content.edit
 import anki.sync.SyncAuth
 import anki.sync.SyncStatusResponse
 import com.ichi2.anki.AnkiDroidApp
@@ -90,14 +91,14 @@ enum class SyncStatus {
                 return
             }
             sMarkedInMemory = true
-            AnkiDroidApp.getSharedPrefs(AnkiDroidApp.instance).edit().putBoolean("changesSinceLastSync", true).apply()
+            AnkiDroidApp.getSharedPrefs(AnkiDroidApp.instance).edit { putBoolean("changesSinceLastSync", true) }
         }
 
         /** To be converted to Rust  */
         @KotlinCleanup("Convert these to @RustCleanup")
         fun markSyncCompleted() {
             sMarkedInMemory = false
-            AnkiDroidApp.getSharedPrefs(AnkiDroidApp.instance).edit().putBoolean("changesSinceLastSync", false).apply()
+            AnkiDroidApp.getSharedPrefs(AnkiDroidApp.instance).edit { putBoolean("changesSinceLastSync", false) }
         }
 
         fun ignoreDatabaseModification(runnable: Runnable) {

--- a/AnkiDroid/src/main/java/com/ichi2/widget/AnkiDroidWidgetSmall.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/widget/AnkiDroidWidgetSmall.kt
@@ -24,6 +24,7 @@ import android.os.IBinder
 import android.util.TypedValue
 import android.view.View
 import android.widget.RemoteViews
+import androidx.core.content.edit
 import com.ichi2.anki.AnkiDroidApp
 import com.ichi2.anki.IntentHandler
 import com.ichi2.anki.R
@@ -43,7 +44,7 @@ class AnkiDroidWidgetSmall : AppWidgetProvider() {
         super.onEnabled(context)
         Timber.d("SmallWidget: Widget enabled")
         val preferences = AnkiDroidApp.getSharedPrefs(context)
-        preferences.edit().putBoolean("widgetSmallEnabled", true).commit()
+        preferences.edit(commit = true) { putBoolean("widgetSmallEnabled", true) }
         UsageAnalytics.sendAnalyticsEvent(this.javaClass.simpleName, "enabled")
     }
 
@@ -51,7 +52,7 @@ class AnkiDroidWidgetSmall : AppWidgetProvider() {
         super.onDisabled(context)
         Timber.d("SmallWidget: Widget disabled")
         val preferences = AnkiDroidApp.getSharedPrefs(context)
-        preferences.edit().putBoolean("widgetSmallEnabled", false).commit()
+        preferences.edit(commit = true) { putBoolean("widgetSmallEnabled", false) }
         UsageAnalytics.sendAnalyticsEvent(this.javaClass.simpleName, "disabled")
     }
 

--- a/AnkiDroid/src/main/res/menu/reviewer.xml
+++ b/AnkiDroid/src/main/res/menu/reviewer.xml
@@ -3,6 +3,13 @@
     android:layoutDirection="locale">
 
     <item
+        android:id="@+id/action_undo"
+        android:enabled="false"
+        android:icon="@drawable/ic_undo_white"
+        android:title="@string/undo"
+        ankidroid:actionProviderClass="com.ichi2.ui.RtlCompliantActionProvider"
+        ankidroid:showAsAction="always"/>
+    <item
         android:id="@+id/action_clear_whiteboard"
         android:title="@string/clear_whiteboard"
         android:icon="@drawable/ic_clear_white"
@@ -21,12 +28,16 @@
         android:visible="false"
         ankidroid:showAsAction="ifRoom"/>
     <item
-        android:id="@+id/action_undo"
-        android:enabled="false"
-        android:icon="@drawable/ic_undo_white"
-        android:title="@string/undo"
-        ankidroid:actionProviderClass="com.ichi2.ui.RtlCompliantActionProvider"
-        ankidroid:showAsAction="always"/>
+        android:id="@+id/action_save_whiteboard"
+        android:title="@string/save_whiteboard"
+        android:icon="@drawable/ic_save_white"
+        android:visible="false"
+        ankidroid:showAsAction="never"/>
+    <item
+        android:id="@+id/action_toggle_whiteboard"
+        android:title="@string/enable_whiteboard"
+        android:icon="@drawable/ic_gesture_white"
+        ankidroid:showAsAction="never"/>
     <item
         android:id="@+id/action_flag"
         android:title="@string/menu_flag_card"
@@ -66,17 +77,6 @@
                 android:icon="@drawable/ic_flag_purple"/>
         </menu>
     </item>
-    <item
-        android:id="@+id/action_save_whiteboard"
-        android:title="@string/save_whiteboard"
-        android:icon="@drawable/ic_save_white"
-        android:visible="false"
-        ankidroid:showAsAction="never"/>
-    <item
-        android:id="@+id/action_toggle_whiteboard"
-        android:title="@string/enable_whiteboard"
-        android:icon="@drawable/ic_gesture_white"
-        ankidroid:showAsAction="never"/>
     <item
         android:id="@+id/action_edit"
         android:icon="@drawable/ic_mode_edit_white"

--- a/AnkiDroid/src/test/java/com/ichi2/anki/BackupManagerSimpleTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/BackupManagerSimpleTest.kt
@@ -134,7 +134,7 @@ class BackupManagerSimpleTest {
         f3.createNewFile()
         f4.createNewFile()
 
-        BackupManager.deleteDeckBackups(colFile.path, 2)
+        BackupManager.deleteColBackups(colFile.path, 2)
         assertThat("Older backups should have been deleted", f2, not(anExistingFile()))
         assertThat("Older backups should have been deleted", f4, not(anExistingFile()))
         assertThat("Newer backups should have been kept", f1, anExistingFile())

--- a/AnkiDroid/src/test/java/com/ichi2/anki/InitialActivityTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/InitialActivityTest.kt
@@ -18,6 +18,7 @@ package com.ichi2.anki
 
 import android.annotation.SuppressLint
 import android.content.SharedPreferences
+import androidx.core.content.edit
 import androidx.test.core.app.ApplicationProvider
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.ichi2.anki.servicelayer.PreferenceUpgradeService
@@ -64,7 +65,7 @@ class InitialActivityTest : RobolectricTest() {
 
     @Test
     fun not_latest_version_with_valid_value() {
-        mSharedPreferences.edit().putString("lastVersion", "0.1").apply()
+        mSharedPreferences.edit { putString("lastVersion", "0.1") }
         assertThat(InitialActivity.isLatestVersion(mSharedPreferences), equalTo(false))
     }
 

--- a/AnkiDroid/src/test/java/com/ichi2/anki/OnboardingFlagTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/OnboardingFlagTest.kt
@@ -18,6 +18,7 @@
 
 package com.ichi2.anki
 
+import androidx.core.content.edit
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.ichi2.anki.OnboardingUtils.Companion.SHOW_ONBOARDING
 import org.junit.After
@@ -37,7 +38,7 @@ class OnboardingFlagTest : RobolectricTest() {
 
     @Before
     fun setShowOnboardingPreference() {
-        AnkiDroidApp.getSharedPrefs(targetContext).edit().putBoolean(SHOW_ONBOARDING, true).apply()
+        AnkiDroidApp.getSharedPrefs(targetContext).edit { putBoolean(SHOW_ONBOARDING, true) }
     }
 
     @After

--- a/AnkiDroid/src/test/java/com/ichi2/libanki/sync/RemoteMediaServerTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/libanki/sync/RemoteMediaServerTest.kt
@@ -16,6 +16,7 @@
 
 package com.ichi2.libanki.sync
 
+import androidx.core.content.edit
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.ichi2.anki.AnkiDroidApp
 import com.ichi2.utils.KotlinCleanup
@@ -91,19 +92,17 @@ class RemoteMediaServerTest {
         assertThat(syncUrl, equalTo(sDefaultUrlWithHostNum))
     }
 
-    @KotlinCleanup("use edit{} extension function")
     private fun setCustomServerWithNoUrl() {
         val userPreferences = AnkiDroidApp.getSharedPrefs(AnkiDroidApp.instance)
-        userPreferences.edit().putBoolean("useCustomSyncServer", true).apply()
+        userPreferences.edit { putBoolean("useCustomSyncServer", true) }
     }
 
-    @KotlinCleanup("use edit{} extension function")
     private fun setCustomMediaServer(s: String) {
-        val userPreferences = AnkiDroidApp.getSharedPrefs(AnkiDroidApp.instance)
-        val e = userPreferences.edit()
-        e.putBoolean("useCustomSyncServer", true)
-        e.putString("syncMediaUrl", s)
-        e.apply()
+        AnkiDroidApp.getSharedPrefs(AnkiDroidApp.instance)
+            .edit {
+                putBoolean("useCustomSyncServer", true)
+                putString("syncMediaUrl", s)
+            }
     }
 
     private fun getServerWithHostNum(hostNum: Int?): RemoteMediaServer {

--- a/AnkiDroid/src/test/java/com/ichi2/utils/FileUtilTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/utils/FileUtilTest.kt
@@ -17,7 +17,7 @@ package com.ichi2.utils
 
 import org.acra.util.IOUtils.writeStringToFile
 import org.hamcrest.CoreMatchers
-import org.hamcrest.MatcherAssert.*
+import org.hamcrest.MatcherAssert.assertThat
 import org.hamcrest.core.IsEqual.equalTo
 import org.junit.Assert.assertThrows
 import org.junit.Rule
@@ -25,9 +25,6 @@ import org.junit.Test
 import org.junit.rules.TemporaryFolder
 import java.io.File
 import java.io.IOException
-import java.lang.Exception
-import java.util.ArrayList
-import kotlin.Throws
 import kotlin.test.assertEquals
 import kotlin.test.assertTrue
 
@@ -43,17 +40,17 @@ class FileUtilTest {
         val childDir2 = File(parentDir, "child2")
         val grandChildDir = File(childDir, "grandChild")
         val grandChild2Dir = File(childDir2, "grandChild2")
-        val files = ArrayList<File>()
-        files.add(File(grandParentDir, "file1.txt"))
-        files.add(File(parentDir, "file2.txt"))
-        files.add(File(childDir, "file3.txt"))
-        files.add(File(childDir2, "file4.txt"))
-        files.add(File(grandChildDir, "file5.txt"))
-        files.add(File(grandChildDir, "file6.txt"))
+        val files = listOf(
+            File(grandParentDir, "file1.txt"),
+            File(parentDir, "file2.txt"),
+            File(childDir, "file3.txt"),
+            File(childDir2, "file4.txt"),
+            File(grandChildDir, "file5.txt"),
+            File(grandChildDir, "file6.txt")
+        )
         grandChildDir.mkdirs()
         grandChild2Dir.mkdirs()
-        for (i in files.indices) {
-            val file = files[i]
+        files.forEachIndexed { i, file ->
             writeStringToFile(file, "File " + (i + 1) + " called " + file.name)
             this.testDirectorySize += file.length()
         }
@@ -68,10 +65,13 @@ class FileUtilTest {
 
         // Test for success scenario
         val dir = createSrcFilesForTest(temporaryRootDir, "dir")
-        assertEquals(FileUtil.getDirectorySize(dir), testDirectorySize)
+        val dirInfo = FileUtil.DirectoryContentInformation.fromDirectory(dir)
+        assertEquals(testDirectorySize, dirInfo.totalBytes, "Directory size is not as expected")
+        assertEquals(5, dirInfo.numberOfSubdirectories, "Wrong number of subdirectories")
+        assertEquals(6, dirInfo.numberOfFiles, "Wrong number of files")
 
         // Test for failure scenario by passing a file as an argument instead of a directory
-        assertThrows(IOException::class.java) { FileUtil.getDirectorySize(File(dir, "file1.txt")) }
+        assertThrows(IOException::class.java) { FileUtil.DirectoryContentInformation.fromDirectory(File(dir, "file1.txt")) }
     }
 
     @Test
@@ -159,18 +159,21 @@ class FileUtilTest {
     @Test
     @Throws(IOException::class)
     fun fileSizeTest() {
-        assertThat("deleted file should have 0 size", FileUtil.getSize(File("test.txt")), equalTo(0L))
-
+        fun sizeFromDir(file: File) = FileUtil.DirectoryContentInformation.fromDirectory(file).totalBytes
         val temporaryRootDir = temporaryDirectory.newFolder("tempRootDir")
 
-        assertThat("empty directory should have 0 size", FileUtil.getSize(temporaryRootDir), equalTo(0L))
+        assertThat("empty directory should have 0 size", sizeFromDir(temporaryRootDir), equalTo(0L))
 
         val textFile = File(temporaryRootDir, "tmp.txt")
         writeStringToFile(textFile, "Hello World")
 
         val expectedLength = "Hello World".length.toLong()
-        assertThat("File size should return text length", FileUtil.getSize(textFile), equalTo(expectedLength))
+        assertThrows("fromDirectory fails on files", IOException::class.java) {
+            sizeFromDir(
+                textFile
+            )
+        }
 
-        assertThat("Should return file lengths", FileUtil.getSize(temporaryRootDir), equalTo(expectedLength))
+        assertThat("Should return file lengths", sizeFromDir(temporaryRootDir), equalTo(expectedLength))
     }
 }


### PR DESCRIPTION
## Pull Request template

## Purpose / Description
On action menu of Study screen, the group of whiteboard-related item is divided by the other items. This PR is to fix it.
![image](https://user-images.githubusercontent.com/10436072/196009970-ad13d3b0-140d-43a8-8d49-98e0ecea2492.png)
## Fixes
Fixes #12672

## Approach
- Move "Undo ~" above "Clear whiteboard"  (i.e. move "Undo ~" to the top of the menu)

- Move "Save whiteboard" and "Disable/Enable whiteboard" above "Flag card" (i.e. move "Flag card" item below the group of whiteboard-related items)

## How Has This Been Tested?
Checked on physical device
![image](https://user-images.githubusercontent.com/10436072/196014894-27f5838f-d2e9-476d-964c-545119b57498.png)
![image](https://user-images.githubusercontent.com/10436072/196014897-cddd0101-7518-4c42-9339-7d36c7be0622.png)



## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [ ] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
