### PR TITLE
Use a not-cloud icon for suggesting backup if no sync

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/BackupPromptDialog.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/BackupPromptDialog.kt
@@ -107,7 +107,7 @@ class BackupPromptDialog private constructor(private val windowContext: Context)
 
     private fun build(isLoggedIn: Boolean, performBackup: () -> Unit) {
         this.materialDialog = MaterialDialog(windowContext).apply {
-            icon(R.drawable.ic_baseline_backup_24)
+            icon(if (isLoggedIn) R.drawable.ic_baseline_backup_24 else R.drawable.ic_backup_restore)
             title(R.string.backup_your_collection)
             message(R.string.backup_collection_message)
             positiveButton(if (isLoggedIn) R.string.button_sync else R.string.button_backup) {

--- a/AnkiDroid/src/main/res/drawable/ic_backup_restore.xml
+++ b/AnkiDroid/src/main/res/drawable/ic_backup_restore.xml
@@ -1,0 +1,10 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24"
+    android:tint="?attr/toolbarIconColor">
+  <path
+      android:fillColor="?attr/iconColor"
+      android:pathData="M14,12c0,-1.1 -0.9,-2 -2,-2s-2,0.9 -2,2 0.9,2 2,2 2,-0.9 2,-2zM12,3c-4.97,0 -9,4.03 -9,9L0,12l4,4 4,-4L5,12c0,-3.87 3.13,-7 7,-7s7,3.13 7,7 -3.13,7 -7,7c-1.51,0 -2.91,-0.49 -4.06,-1.3l-1.42,1.44C8.04,20.3 9.94,21 12,21c4.97,0 9,-4.03 9,-9s-4.03,-9 -9,-9z" />
+</vector>


### PR DESCRIPTION
(Use a not-cloud design for the icon of the backup suggestion dialog box if the user doesn't use the sync feature)

## Pull Request template

## Purpose / Description
The current icon with an upward arrow in a cloud alludes uploading data to cloud (AnkiWeb). Its design is misleading for encouraging backup to those who don't use the sync feature.

![image](https://user-images.githubusercontent.com/10436072/233231078-772729b0-a531-41b5-9eed-2241d838a286.png)
Left: logged in state /  Right: logged out state




## Fixes
Fixes _Link to the issues._

## Approach
- Add a new icon. Its resource is [the "File Copy" icon on Google Fonts](https://fonts.google.com/icons?selected=Material%20Symbols%20Outlined%3Afile_copy%3AFILL%400%3Bwght%40400%3BGRAD%400%3Bopsz%4048).
- Replace the current icon with it if the user hasn't logged in to their AnkiWeb account.



## How Has This Been Tested?

- Checked on a physical device (Android 11) with logged out state
  <img src="https://user-images.githubusercontent.com/10436072/233270674-113613af-b608-40df-8c9e-1e9d5b941151.png" width="320px"> <img src="https://user-images.githubusercontent.com/10436072/233270831-94172adf-218e-44b1-85eb-ff07c7fdb454.png" width="320px">
Left: After change  /  Right: Before change

  <img src="https://user-images.githubusercontent.com/10436072/233271647-3f7b1b90-faa1-42d9-9a41-6b2da29b23fd.png" width="320px"> <img src="https://user-images.githubusercontent.com/10436072/233271721-c2aca8ef-84f9-46a5-8067-c7d24b58a678.png" width="320px">
  Left: After change  /  Right: Before change

- Checked as well with logged in state. As expected, nothing seems to be affected by this commit.
<img src="https://user-images.githubusercontent.com/10436072/233324785-5e830233-c118-485d-bdd3-f64e8b9712f6.png" width="300px"> <img src="https://user-images.githubusercontent.com/10436072/233324911-bacafdbe-19a3-4ab7-b022-1b6e0bde7b47.png" width="300px">
## Learning (optional, can help others)
n/a



## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [ ] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [x] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
