### PR TITLE
Use "Finish" as Timebox negative button label

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.kt
@@ -474,7 +474,7 @@ abstract class AbstractFlashcardViewer :
                     positiveButton(R.string.dialog_continue) {
                         col.startTimebox()
                     }
-                    negativeButton(R.string.close) {
+                    negativeButton(text = TR.studyingFinish()) {
                         finishWithAnimation(ActivityTransitionAnimation.Direction.END)
                     }
                     cancelable(true)

--- a/AnkiDroid/src/main/res/values/02-strings.xml
+++ b/AnkiDroid/src/main/res/values/02-strings.xml
@@ -110,11 +110,13 @@
     <string name="field_remapping">%1$s (from “%2$s”)</string>
     <string name="confirm_map_cards_to_nothing">Any cards mapped to nothing will be deleted. If a note has no remaining cards, it will be lost. Are you sure you want to continue?</string>
 
+    <!-- Timebox -->
     <string name="timebox_reached_title">Timebox reached</string>
     <plurals name="timebox_reached">
         <item quantity="one">%1$d card studied in %2$s</item>
         <item quantity="other">%1$d cards studied in %2$s</item>
     </plurals>
+
     <!-- minutes used in '[studied in] x minutes' context, causing inflexion in some languages -->
     <plurals name="in_minutes">
         <item quantity="one">%1$d minute</item>


### PR DESCRIPTION


## Pull Request template

## Purpose / Description
The current label of the negative button of "Timebox reached" dialog is "Close", but it misleads as if it merely closes the dialog. (It actually finishes the review session and shows the deck picker screen.)
<img src="https://github.com/snowtimeglass/Anki-Android/assets/10436072/01fd009b-86d3-4753-b1e2-0cd817d76ed0" width="320px">


This commit will replace the label with "Finish", which is used on the same dialog in Anki Desktop.
![image](https://github.com/snowtimeglass/Anki-Android/assets/10436072/eb198618-f24d-4dea-b02b-8465e7fe3cf6)
## Fixes
N/A

## Approach
- Add a new string
- Replace the current string with the new one

## How Has This Been Tested?
Checked on an emulator (Pixel 2 / API 30)
<img src="https://github.com/snowtimeglass/Anki-Android/assets/10436072/85a652f8-2829-42d0-bd30-f5ad7ab2dc77" width="320px">

## Checklist
_Please, go through these checks before submitting the PR._

- [ ] You have a descriptive commit message with a short title (first line, max 50 chars).
- [ ] You have commented your code, particularly in hard-to-understand areas
- [ ] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
