### PR TITLE
fix: top side is cut off when center align & long

### DIFF
--- a/AnkiDroid/src/main/assets/flashcard.css
+++ b/AnkiDroid/src/main/assets/flashcard.css
@@ -116,7 +116,7 @@ preferred over using JavaScript.
 .vertically_centered {
   position: absolute;
   width: 100%;
-  height: 100%;
+  min-height: 100%;
   display: -webkit-box;
   -webkit-box-align: stretch;
   -webkit-box-pack: center;


### PR DESCRIPTION
issue: if "Center aling" is enabled and the content of the card is so long that cannot be shown entirely without scrolling, the top side of the content is trimmed.

<!--- Please fill the necessary details below -->
## Purpose / Description
_Describe the problem or feature and motivation_

## Fixes
* Fixes #<!-- replace this comment with the issue number e.g. 'Fixes #100'-->

## Approach
_How does this change address the problem?_

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration (SDK version(s), emulator or physical, etc)

## Learning (optional, can help others)
_Describe the research stage_

_Links to blog posts, patterns, libraries or addons used to solve this problem_

## Checklist
_Please, go through these checks before submitting the PR._

- [ ] You have a descriptive commit message with a short title (first line, max 50 chars).
- [ ] You have commented your code, particularly in hard-to-understand areas
- [ ] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
